### PR TITLE
Disable globalization invariance to support rare/old collations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ RUN dotnet publish -c Release -r linux-musl-x64 -o out --self-contained true /p:
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1-alpine AS runtime
 EXPOSE 80
 WORKDIR /app
+RUN apk add --no-cache icu-libs
 COPY --from=build /app/server/out ./
 ENTRYPOINT ["./mssql_exporter", "serve"]

--- a/src/server/server.csproj
+++ b/src/server/server.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="false" />
   </ItemGroup> 
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #3 and #8.

This disables dotnet **globalization invariance**, adding support for older db collations such as Latin1_General_CI_AS. To support those collations in the docker image, the `icu-libs` package was added.

The downside of this change is in the docker image size, increasing from 68MB to 101MB.